### PR TITLE
Generate responses

### DIFF
--- a/dei_app/lib/dei_app/responses.ex
+++ b/dei_app/lib/dei_app/responses.ex
@@ -1,0 +1,104 @@
+defmodule DeiApp.Responses do
+  @moduledoc """
+  The Responses context.
+  """
+
+  import Ecto.Query, warn: false
+  alias DeiApp.Repo
+
+  alias DeiApp.Responses.Response
+
+  @doc """
+  Returns the list of responses.
+
+  ## Examples
+
+      iex> list_responses()
+      [%Response{}, ...]
+
+  """
+  def list_responses do
+    Repo.all(Response)
+  end
+
+  @doc """
+  Gets a single response.
+
+  Raises `Ecto.NoResultsError` if the Response does not exist.
+
+  ## Examples
+
+      iex> get_response!(123)
+      %Response{}
+
+      iex> get_response!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_response!(id), do: Repo.get!(Response, id)
+
+  @doc """
+  Creates a response.
+
+  ## Examples
+
+      iex> create_response(%{field: value})
+      {:ok, %Response{}}
+
+      iex> create_response(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_response(attrs \\ %{}) do
+    %Response{}
+    |> Response.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a response.
+
+  ## Examples
+
+      iex> update_response(response, %{field: new_value})
+      {:ok, %Response{}}
+
+      iex> update_response(response, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_response(%Response{} = response, attrs) do
+    response
+    |> Response.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a response.
+
+  ## Examples
+
+      iex> delete_response(response)
+      {:ok, %Response{}}
+
+      iex> delete_response(response)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_response(%Response{} = response) do
+    Repo.delete(response)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking response changes.
+
+  ## Examples
+
+      iex> change_response(response)
+      %Ecto.Changeset{data: %Response{}}
+
+  """
+  def change_response(%Response{} = response, attrs \\ %{}) do
+    Response.changeset(response, attrs)
+  end
+end

--- a/dei_app/lib/dei_app/responses/response.ex
+++ b/dei_app/lib/dei_app/responses/response.ex
@@ -1,0 +1,27 @@
+defmodule DeiApp.Responses.Response do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "responses" do
+    field :compensation_amount, :integer
+    field :email, :string
+    field :employment_type, :string
+    field :feedback, :string
+    field :gender, :string
+    field :is_hispanic_latinx, :boolean, default: false
+    field :may_include_salary, :boolean, default: false
+    field :races, {:array, :string}
+    field :tenure, :integer
+    field :work_category, :string
+    field :campaign_id, :id
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(response, attrs) do
+    response
+    |> cast(attrs, [:email, :gender, :races, :is_hispanic_latinx, :employment_type, :work_category, :tenure, :compensation_amount, :may_include_salary, :feedback])
+    |> validate_required([:email, :gender, :races, :is_hispanic_latinx, :employment_type, :work_category, :tenure, :compensation_amount, :may_include_salary, :feedback])
+  end
+end

--- a/dei_app/lib/dei_app_web/live/response_live/form_component.ex
+++ b/dei_app/lib/dei_app_web/live/response_live/form_component.ex
@@ -1,0 +1,55 @@
+defmodule DeiAppWeb.ResponseLive.FormComponent do
+  use DeiAppWeb, :live_component
+
+  alias DeiApp.Responses
+
+  @impl true
+  def update(%{response: response} = assigns, socket) do
+    changeset = Responses.change_response(response)
+
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign(:changeset, changeset)}
+  end
+
+  @impl true
+  def handle_event("validate", %{"response" => response_params}, socket) do
+    changeset =
+      socket.assigns.response
+      |> Responses.change_response(response_params)
+      |> Map.put(:action, :validate)
+
+    {:noreply, assign(socket, :changeset, changeset)}
+  end
+
+  def handle_event("save", %{"response" => response_params}, socket) do
+    save_response(socket, socket.assigns.action, response_params)
+  end
+
+  defp save_response(socket, :edit, response_params) do
+    case Responses.update_response(socket.assigns.response, response_params) do
+      {:ok, _response} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Response updated successfully")
+         |> push_redirect(to: socket.assigns.return_to)}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, :changeset, changeset)}
+    end
+  end
+
+  defp save_response(socket, :new, response_params) do
+    case Responses.create_response(response_params) do
+      {:ok, _response} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Response created successfully")
+         |> push_redirect(to: socket.assigns.return_to)}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, changeset: changeset)}
+    end
+  end
+end

--- a/dei_app/lib/dei_app_web/live/response_live/form_component.html.leex
+++ b/dei_app/lib/dei_app_web/live/response_live/form_component.html.leex
@@ -1,0 +1,50 @@
+<h2><%= @title %></h2>
+
+<%= f = form_for @changeset, "#",
+  id: "response-form",
+  phx_target: @myself,
+  phx_change: "validate",
+  phx_submit: "save" %>
+
+  <%= label f, :email %>
+  <%= text_input f, :email %>
+  <%= error_tag f, :email %>
+
+  <%= label f, :gender %>
+  <%= text_input f, :gender %>
+  <%= error_tag f, :gender %>
+
+  <%= label f, :races %>
+  <%= multiple_select f, :races, ["Option 1": "option1", "Option 2": "option2"] %>
+  <%= error_tag f, :races %>
+
+  <%= label f, :is_hispanic_latinx %>
+  <%= checkbox f, :is_hispanic_latinx %>
+  <%= error_tag f, :is_hispanic_latinx %>
+
+  <%= label f, :employment_type %>
+  <%= text_input f, :employment_type %>
+  <%= error_tag f, :employment_type %>
+
+  <%= label f, :work_category %>
+  <%= text_input f, :work_category %>
+  <%= error_tag f, :work_category %>
+
+  <%= label f, :tenure %>
+  <%= number_input f, :tenure %>
+  <%= error_tag f, :tenure %>
+
+  <%= label f, :compensation_amount %>
+  <%= number_input f, :compensation_amount %>
+  <%= error_tag f, :compensation_amount %>
+
+  <%= label f, :may_include_salary %>
+  <%= checkbox f, :may_include_salary %>
+  <%= error_tag f, :may_include_salary %>
+
+  <%= label f, :feedback %>
+  <%= textarea f, :feedback %>
+  <%= error_tag f, :feedback %>
+
+  <%= submit "Save", phx_disable_with: "Saving..." %>
+</form>

--- a/dei_app/lib/dei_app_web/live/response_live/index.ex
+++ b/dei_app/lib/dei_app_web/live/response_live/index.ex
@@ -1,0 +1,46 @@
+defmodule DeiAppWeb.ResponseLive.Index do
+  use DeiAppWeb, :live_view
+
+  alias DeiApp.Responses
+  alias DeiApp.Responses.Response
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, :responses, list_responses())}
+  end
+
+  @impl true
+  def handle_params(params, _url, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+  end
+
+  defp apply_action(socket, :edit, %{"id" => id}) do
+    socket
+    |> assign(:page_title, "Edit Response")
+    |> assign(:response, Responses.get_response!(id))
+  end
+
+  defp apply_action(socket, :new, _params) do
+    socket
+    |> assign(:page_title, "New Response")
+    |> assign(:response, %Response{})
+  end
+
+  defp apply_action(socket, :index, _params) do
+    socket
+    |> assign(:page_title, "Listing Responses")
+    |> assign(:response, nil)
+  end
+
+  @impl true
+  def handle_event("delete", %{"id" => id}, socket) do
+    response = Responses.get_response!(id)
+    {:ok, _} = Responses.delete_response(response)
+
+    {:noreply, assign(socket, :responses, list_responses())}
+  end
+
+  defp list_responses do
+    Responses.list_responses()
+  end
+end

--- a/dei_app/lib/dei_app_web/live/response_live/index.html.leex
+++ b/dei_app/lib/dei_app_web/live/response_live/index.html.leex
@@ -1,0 +1,53 @@
+<h1>Listing Responses</h1>
+
+<%= if @live_action in [:new, :edit] do %>
+  <%= live_modal @socket, DeiAppWeb.ResponseLive.FormComponent,
+    id: @response.id || :new,
+    title: @page_title,
+    action: @live_action,
+    response: @response,
+    return_to: Routes.response_index_path(@socket, :index) %>
+<% end %>
+
+<table>
+  <thead>
+    <tr>
+      <th>Email</th>
+      <th>Gender</th>
+      <th>Races</th>
+      <th>Is hispanic latinx</th>
+      <th>Employment type</th>
+      <th>Work category</th>
+      <th>Tenure</th>
+      <th>Compensation amount</th>
+      <th>May include salary</th>
+      <th>Feedback</th>
+
+      <th></th>
+    </tr>
+  </thead>
+  <tbody id="responses">
+    <%= for response <- @responses do %>
+      <tr id="response-<%= response.id %>">
+        <td><%= response.email %></td>
+        <td><%= response.gender %></td>
+        <td><%= response.races %></td>
+        <td><%= response.is_hispanic_latinx %></td>
+        <td><%= response.employment_type %></td>
+        <td><%= response.work_category %></td>
+        <td><%= response.tenure %></td>
+        <td><%= response.compensation_amount %></td>
+        <td><%= response.may_include_salary %></td>
+        <td><%= response.feedback %></td>
+
+        <td>
+          <span><%= live_redirect "Show", to: Routes.response_show_path(@socket, :show, response) %></span>
+          <span><%= live_patch "Edit", to: Routes.response_index_path(@socket, :edit, response) %></span>
+          <span><%= link "Delete", to: "#", phx_click: "delete", phx_value_id: response.id, data: [confirm: "Are you sure?"] %></span>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<span><%= live_patch "New Response", to: Routes.response_index_path(@socket, :new) %></span>

--- a/dei_app/lib/dei_app_web/live/response_live/show.ex
+++ b/dei_app/lib/dei_app_web/live/response_live/show.ex
@@ -1,0 +1,21 @@
+defmodule DeiAppWeb.ResponseLive.Show do
+  use DeiAppWeb, :live_view
+
+  alias DeiApp.Responses
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(%{"id" => id}, _, socket) do
+    {:noreply,
+     socket
+     |> assign(:page_title, page_title(socket.assigns.live_action))
+     |> assign(:response, Responses.get_response!(id))}
+  end
+
+  defp page_title(:show), do: "Show Response"
+  defp page_title(:edit), do: "Edit Response"
+end

--- a/dei_app/lib/dei_app_web/live/response_live/show.html.leex
+++ b/dei_app/lib/dei_app_web/live/response_live/show.html.leex
@@ -1,0 +1,67 @@
+<h1>Show Response</h1>
+
+<%= if @live_action in [:edit] do %>
+  <%= live_modal @socket, DeiAppWeb.ResponseLive.FormComponent,
+    id: @response.id,
+    title: @page_title,
+    action: @live_action,
+    response: @response,
+    return_to: Routes.response_show_path(@socket, :show, @response) %>
+<% end %>
+
+<ul>
+
+  <li>
+    <strong>Email:</strong>
+    <%= @response.email %>
+  </li>
+
+  <li>
+    <strong>Gender:</strong>
+    <%= @response.gender %>
+  </li>
+
+  <li>
+    <strong>Races:</strong>
+    <%= @response.races %>
+  </li>
+
+  <li>
+    <strong>Is hispanic latinx:</strong>
+    <%= @response.is_hispanic_latinx %>
+  </li>
+
+  <li>
+    <strong>Employment type:</strong>
+    <%= @response.employment_type %>
+  </li>
+
+  <li>
+    <strong>Work category:</strong>
+    <%= @response.work_category %>
+  </li>
+
+  <li>
+    <strong>Tenure:</strong>
+    <%= @response.tenure %>
+  </li>
+
+  <li>
+    <strong>Compensation amount:</strong>
+    <%= @response.compensation_amount %>
+  </li>
+
+  <li>
+    <strong>May include salary:</strong>
+    <%= @response.may_include_salary %>
+  </li>
+
+  <li>
+    <strong>Feedback:</strong>
+    <%= @response.feedback %>
+  </li>
+
+</ul>
+
+<span><%= live_patch "Edit", to: Routes.response_show_path(@socket, :edit, @response), class: "button" %></span>
+<span><%= live_redirect "Back", to: Routes.response_index_path(@socket, :index) %></span>

--- a/dei_app/lib/dei_app_web/router.ex
+++ b/dei_app/lib/dei_app_web/router.ex
@@ -32,6 +32,12 @@ defmodule DeiAppWeb.Router do
     get("/login", SessionController, :new)
     post("/login", SessionController, :login)
     get("/logout", SessionController, :logout)
+
+    live "/responses", ResponseLive.Index, :index
+    live "/responses/new", ResponseLive.Index, :new
+    live "/responses/:id/edit", ResponseLive.Index, :edit
+    live "/responses/:id", ResponseLive.Show, :show
+    live "/responses/:id/show/edit", ResponseLive.Show, :edit
   end
 
   # Definitely logged in scope

--- a/dei_app/priv/repo/migrations/20200908144649_create_responses.exs
+++ b/dei_app/priv/repo/migrations/20200908144649_create_responses.exs
@@ -1,0 +1,23 @@
+defmodule DeiApp.Repo.Migrations.CreateResponses do
+  use Ecto.Migration
+
+  def change do
+    create table(:responses) do
+      add :email, :string
+      add :gender, :string
+      add :races, {:array, :string}
+      add :is_hispanic_latinx, :boolean, default: false, null: false
+      add :employment_type, :string
+      add :work_category, :string
+      add :tenure, :integer
+      add :compensation_amount, :integer
+      add :may_include_salary, :boolean, default: false, null: false
+      add :feedback, :text
+      add :campaign_id, references(:campaigns, on_delete: :nothing)
+
+      timestamps()
+    end
+
+    create index(:responses, [:campaign_id])
+  end
+end

--- a/dei_app/test/dei_app/responses_test.exs
+++ b/dei_app/test/dei_app/responses_test.exs
@@ -1,0 +1,82 @@
+defmodule DeiApp.ResponsesTest do
+  use DeiApp.DataCase
+
+  alias DeiApp.Responses
+
+  describe "responses" do
+    alias DeiApp.Responses.Response
+
+    @valid_attrs %{compensation_amount: 42, email: "some email", employment_type: "some employment_type", feedback: "some feedback", gender: "some gender", is_hispanic_latinx: true, may_include_salary: true, races: [], tenure: 42, work_category: "some work_category"}
+    @update_attrs %{compensation_amount: 43, email: "some updated email", employment_type: "some updated employment_type", feedback: "some updated feedback", gender: "some updated gender", is_hispanic_latinx: false, may_include_salary: false, races: [], tenure: 43, work_category: "some updated work_category"}
+    @invalid_attrs %{compensation_amount: nil, email: nil, employment_type: nil, feedback: nil, gender: nil, is_hispanic_latinx: nil, may_include_salary: nil, races: nil, tenure: nil, work_category: nil}
+
+    def response_fixture(attrs \\ %{}) do
+      {:ok, response} =
+        attrs
+        |> Enum.into(@valid_attrs)
+        |> Responses.create_response()
+
+      response
+    end
+
+    test "list_responses/0 returns all responses" do
+      response = response_fixture()
+      assert Responses.list_responses() == [response]
+    end
+
+    test "get_response!/1 returns the response with given id" do
+      response = response_fixture()
+      assert Responses.get_response!(response.id) == response
+    end
+
+    test "create_response/1 with valid data creates a response" do
+      assert {:ok, %Response{} = response} = Responses.create_response(@valid_attrs)
+      assert response.compensation_amount == 42
+      assert response.email == "some email"
+      assert response.employment_type == "some employment_type"
+      assert response.feedback == "some feedback"
+      assert response.gender == "some gender"
+      assert response.is_hispanic_latinx == true
+      assert response.may_include_salary == true
+      assert response.races == []
+      assert response.tenure == 42
+      assert response.work_category == "some work_category"
+    end
+
+    test "create_response/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Responses.create_response(@invalid_attrs)
+    end
+
+    test "update_response/2 with valid data updates the response" do
+      response = response_fixture()
+      assert {:ok, %Response{} = response} = Responses.update_response(response, @update_attrs)
+      assert response.compensation_amount == 43
+      assert response.email == "some updated email"
+      assert response.employment_type == "some updated employment_type"
+      assert response.feedback == "some updated feedback"
+      assert response.gender == "some updated gender"
+      assert response.is_hispanic_latinx == false
+      assert response.may_include_salary == false
+      assert response.races == []
+      assert response.tenure == 43
+      assert response.work_category == "some updated work_category"
+    end
+
+    test "update_response/2 with invalid data returns error changeset" do
+      response = response_fixture()
+      assert {:error, %Ecto.Changeset{}} = Responses.update_response(response, @invalid_attrs)
+      assert response == Responses.get_response!(response.id)
+    end
+
+    test "delete_response/1 deletes the response" do
+      response = response_fixture()
+      assert {:ok, %Response{}} = Responses.delete_response(response)
+      assert_raise Ecto.NoResultsError, fn -> Responses.get_response!(response.id) end
+    end
+
+    test "change_response/1 returns a response changeset" do
+      response = response_fixture()
+      assert %Ecto.Changeset{} = Responses.change_response(response)
+    end
+  end
+end

--- a/dei_app/test/dei_app_web/live/response_live_test.exs
+++ b/dei_app/test/dei_app_web/live/response_live_test.exs
@@ -1,0 +1,116 @@
+defmodule DeiAppWeb.ResponseLiveTest do
+  use DeiAppWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  alias DeiApp.Responses
+
+  @create_attrs %{compensation_amount: 42, email: "some email", employment_type: "some employment_type", feedback: "some feedback", gender: "some gender", is_hispanic_latinx: true, may_include_salary: true, races: [], tenure: 42, work_category: "some work_category"}
+  @update_attrs %{compensation_amount: 43, email: "some updated email", employment_type: "some updated employment_type", feedback: "some updated feedback", gender: "some updated gender", is_hispanic_latinx: false, may_include_salary: false, races: [], tenure: 43, work_category: "some updated work_category"}
+  @invalid_attrs %{compensation_amount: nil, email: nil, employment_type: nil, feedback: nil, gender: nil, is_hispanic_latinx: nil, may_include_salary: nil, races: nil, tenure: nil, work_category: nil}
+
+  defp fixture(:response) do
+    {:ok, response} = Responses.create_response(@create_attrs)
+    response
+  end
+
+  defp create_response(_) do
+    response = fixture(:response)
+    %{response: response}
+  end
+
+  describe "Index" do
+    setup [:create_response]
+
+    test "lists all responses", %{conn: conn, response: response} do
+      {:ok, _index_live, html} = live(conn, Routes.response_index_path(conn, :index))
+
+      assert html =~ "Listing Responses"
+      assert html =~ response.email
+    end
+
+    test "saves new response", %{conn: conn} do
+      {:ok, index_live, _html} = live(conn, Routes.response_index_path(conn, :index))
+
+      assert index_live |> element("a", "New Response") |> render_click() =~
+               "New Response"
+
+      assert_patch(index_live, Routes.response_index_path(conn, :new))
+
+      assert index_live
+             |> form("#response-form", response: @invalid_attrs)
+             |> render_change() =~ "can&apos;t be blank"
+
+      {:ok, _, html} =
+        index_live
+        |> form("#response-form", response: @create_attrs)
+        |> render_submit()
+        |> follow_redirect(conn, Routes.response_index_path(conn, :index))
+
+      assert html =~ "Response created successfully"
+      assert html =~ "some email"
+    end
+
+    test "updates response in listing", %{conn: conn, response: response} do
+      {:ok, index_live, _html} = live(conn, Routes.response_index_path(conn, :index))
+
+      assert index_live |> element("#response-#{response.id} a", "Edit") |> render_click() =~
+               "Edit Response"
+
+      assert_patch(index_live, Routes.response_index_path(conn, :edit, response))
+
+      assert index_live
+             |> form("#response-form", response: @invalid_attrs)
+             |> render_change() =~ "can&apos;t be blank"
+
+      {:ok, _, html} =
+        index_live
+        |> form("#response-form", response: @update_attrs)
+        |> render_submit()
+        |> follow_redirect(conn, Routes.response_index_path(conn, :index))
+
+      assert html =~ "Response updated successfully"
+      assert html =~ "some updated email"
+    end
+
+    test "deletes response in listing", %{conn: conn, response: response} do
+      {:ok, index_live, _html} = live(conn, Routes.response_index_path(conn, :index))
+
+      assert index_live |> element("#response-#{response.id} a", "Delete") |> render_click()
+      refute has_element?(index_live, "#response-#{response.id}")
+    end
+  end
+
+  describe "Show" do
+    setup [:create_response]
+
+    test "displays response", %{conn: conn, response: response} do
+      {:ok, _show_live, html} = live(conn, Routes.response_show_path(conn, :show, response))
+
+      assert html =~ "Show Response"
+      assert html =~ response.email
+    end
+
+    test "updates response within modal", %{conn: conn, response: response} do
+      {:ok, show_live, _html} = live(conn, Routes.response_show_path(conn, :show, response))
+
+      assert show_live |> element("a", "Edit") |> render_click() =~
+               "Edit Response"
+
+      assert_patch(show_live, Routes.response_show_path(conn, :edit, response))
+
+      assert show_live
+             |> form("#response-form", response: @invalid_attrs)
+             |> render_change() =~ "can&apos;t be blank"
+
+      {:ok, _, html} =
+        show_live
+        |> form("#response-form", response: @update_attrs)
+        |> render_submit()
+        |> follow_redirect(conn, Routes.response_show_path(conn, :show, response))
+
+      assert html =~ "Response updated successfully"
+      assert html =~ "some updated email"
+    end
+  end
+end


### PR DESCRIPTION
Ran: `mix phx.gen.live Responses Response responses
campaign_id:references:campaigns email:string gender:string
races:array:string is_hispanic_latinx:boolean employment_type:string
work_category:string tenure:integer compensation_amount:integer
may_include_salary:boolean feedback:text`.

Add the responses live routes to the router.

Depends on https://github.com/mbta/diversity_dashboard/pull/29